### PR TITLE
Replaced division by 2 with modular inverse for correctness under mod q

### DIFF
--- a/proof-of-decryption/scripts/vdec_params_generator.sage
+++ b/proof-of-decryption/scripts/vdec_params_generator.sage
@@ -388,8 +388,8 @@ out += f"""
 {int_t(f"{name}_stdev1sq", int(mp.nint(stdev1^2)), 2*q_nlimbs)}
 {int_t(f"{name}_stdev2sq", int(mp.nint(stdev2^2)), 2*q_nlimbs)}
 {int_t(f"{name}_stdev4sq", int(mp.nint(stdev4^2)), 2*q_nlimbs)}
-{int_t(f"{name}_inv2", redc(1/2 % q, q))}
-{int_t(f"{name}_inv4", redc(1/4 % q, q))}
+{int_t(f"{name}_inv2", redc(inverse_mod(2, q), q))}
+{int_t(f"{name}_inv4", redc(inverse_mod(4, q), q))}
 {int_t(f"{name}_Bz4", Bz4, 2*q_nlimbs)}
 static const polyring_t {name}_ring = {{{{{name}_q, {d}, {ceil(log(q-1,2))}, {log2d}, moduli_d{d}, {nmoduli}, {name}_inv2}}}};
 static const dcompress_params_t {name}_dcomp = {{{{ {name}_q, {name}_qminus1, {name}_m, {name}_mby2, {name}_gamma, {name}_gammaby2, {name}_pow2D, {name}_pow2Dby2, {D}, {m % 2}, {ceil(log(m,2))} }}}};


### PR DESCRIPTION
Resolved ambiguity in 1/2 by replacing it with mod_inverse(2, q) to ensure consistent interpretation over prime fields rather than the rational field. This avoids unintended behavior in modular arithmetic by explicitly computing the inverse modulo q.